### PR TITLE
Force rescan from height (if key already imported)

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -110,6 +110,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importprivkey", 2 },
     { "importprivkey", 3 },
     { "importprivkey", 4 },
+    { "importprivkey", 5 },
     { "importaddress", 2 },
     { "verifychain", 0 },
     { "verifychain", 1 },

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -239,14 +239,10 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             if (pwalletMain->HaveKey(vchAddress)) {
                 return EncodeDestination(vchAddress);
             }
-        if (!pwalletMain->AddKeyPubKey(key, pubkey))
-            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
+            if (!pwalletMain->AddKeyPubKey(key, pubkey))
+                throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
+	    pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
 	}
-	else	{
-
-	}
-
-        pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
 
         // whenever a key is imported, we need to scan the whole chain
         pwalletMain->nTimeFirstKey = 1; // 0 would be considered 'no value'

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -162,8 +162,8 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             "2. \"label\"            (string, optional, default=\"\") An optional label\n"
             "3. rescan               (boolean, optional, default=true) Rescan the wallet for transactions\n"
             "4. height               (integer, optional, default=0) start at block height?\n"
-            "5. force_rescan         (boolean, optional, default=false) used to force the rescan (if the key was already imported)\n" 
-	    "6. secret_key           (integer, optional, default=188) used to import WIFs of other coins\n" 
+            "5. secret_key           (integer, optional, default=188) used to import WIFs of other coins\n" 
+	    "6. force_rescan         (boolean, optional, default=false) used to force the rescan (if the key was already imported)\n" 
             "\nNote: This call can take minutes to complete if rescan is true.\n"
             "\nExamples:\n"
             "\nDump a private key\n"
@@ -177,13 +177,13 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             "\nImport with rescan from a block height\n"
             + HelpExampleCli("importprivkey", "\"mykey\" \"testing\" true 1000") +
             "\nImport a BTC WIF with rescan (no need to force the rescan if the key was not imported yet)\n"
-            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" true 0 false 128") +
+            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" true 0 128") +
             "\nImport a KMD WIF with forced rescan\n"
-            + HelpExampleCli("importprivkey", "\"KMDWIF\" \"testing\" true 120000 true") +
+            + HelpExampleCli("importprivkey", "\"KMDWIF\" \"testing\" true 120000 188 true") +
             "\nImport a BTC WIF with forced rescan\n"
-            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" true 120000 true 128") +
+            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" true 120000 128 true") +
             "\nImport a BTC WIF without rescan\n"
-            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" false 0 false 128") +
+            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" false 0 128 false") +
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("importprivkey", "\"mykey\", \"testing\", true, 1000")
         );
@@ -207,9 +207,9 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     if ( fRescan && params.size() >= 4 )
         height = params[3].get_int();
 
-    if (params.size() > 5)
+    if (params.size() > 4)
     {
-        auto secret_key = AmountFromValue(params[5])/100000000;
+        auto secret_key = AmountFromValue(params[4])/100000000;
         key = DecodeCustomSecret(strSecret, secret_key);
     } else {
         key = DecodeSecret(strSecret);
@@ -217,9 +217,9 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
 
     // Force the rescan (if the key was already imported)
     bool fForceRescan = false;
-    if (params.size() > 4)
+    if (params.size() > 5)
     {
-        fForceRescan = params[4].get_bool();
+        fForceRescan = params[5].get_bool();
     }
 
     if ( height < 0 || height > chainActive.Height() )
@@ -241,11 +241,11 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             }
             if (!pwalletMain->AddKeyPubKey(key, pubkey))
                 throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
-	    pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
+	    pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1; // phm87: Not sure if it should be move according to fForceRescan
 	}
 
         // whenever a key is imported, we need to scan the whole chain
-        pwalletMain->nTimeFirstKey = 1; // 0 would be considered 'no value'
+        pwalletMain->nTimeFirstKey = 1; // 0 would be considered 'no value' - phm87: Not sure if it should be move according to fForceRescan
 
         if (fRescan) {
             pwalletMain->ScanForWalletTransactions(chainActive[height], true);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -204,7 +204,7 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     bool fRescan = true;
     if (params.size() > 2)
         fRescan = params[2].get_bool();
-    if ( fRescan && params.size() == 4 )
+    if ( fRescan && params.size() >= 4 )
         height = params[3].get_int();
 
     if (params.size() > 5)

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -239,15 +239,14 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             if (pwalletMain->HaveKey(vchAddress)) {
                 return EncodeDestination(vchAddress);
             }
+        if (!pwalletMain->AddKeyPubKey(key, pubkey))
+            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
 	}
 	else	{
 
 	}
 
         pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
-
-        if (!pwalletMain->AddKeyPubKey(key, pubkey))
-            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
 
         // whenever a key is imported, we need to scan the whole chain
         pwalletMain->nTimeFirstKey = 1; // 0 would be considered 'no value'

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -162,8 +162,8 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             "2. \"label\"            (string, optional, default=\"\") An optional label\n"
             "3. rescan               (boolean, optional, default=true) Rescan the wallet for transactions\n"
             "4. height               (integer, optional, default=0) start at block height?\n"
-            "5. secret_key           (integer, optional, default=188) used to import WIFs of other coins\n" 
-	    "6. force_rescan         (boolean, optional, default=false) used to force the rescan (if the key was already imported)\n" 
+            "5. force_rescan         (boolean, optional, default=false) used to force the rescan (if the key was already imported)\n" 
+	    "6. secret_key           (integer, optional, default=188) used to import WIFs of other coins\n" 
             "\nNote: This call can take minutes to complete if rescan is true.\n"
             "\nExamples:\n"
             "\nDump a private key\n"
@@ -176,12 +176,14 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             + HelpExampleRpc("importprivkey", "\"mykey\", \"testing\", false") +
             "\nImport with rescan from a block height\n"
             + HelpExampleCli("importprivkey", "\"mykey\" \"testing\" true 1000") +
-            "\nImport a BTC WIF with rescan\n"
-            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" true 0 128") +
+            "\nImport a BTC WIF with rescan (no need to force the rescan if the key was not imported yet)\n"
+            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" true 0 false 128") +
             "\nImport a KMD WIF with forced rescan\n"
-            + HelpExampleCli("importprivkey", "\"KMDWIF\" \"testing\" true 120000 128 true") +
+            + HelpExampleCli("importprivkey", "\"KMDWIF\" \"testing\" true 120000 true") +
+            "\nImport a BTC WIF with forced rescan\n"
+            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" true 120000 true 128") +
             "\nImport a BTC WIF without rescan\n"
-            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" false 0 128") +
+            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" false 0 false 128") +
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("importprivkey", "\"mykey\", \"testing\", true, 1000")
         );
@@ -205,9 +207,9 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     if ( fRescan && params.size() == 4 )
         height = params[3].get_int();
 
-    if (params.size() > 4 && params.size() <= 5) // Hack to fix later
+    if (params.size() > 5)
     {
-        auto secret_key = AmountFromValue(params[4])/100000000;
+        auto secret_key = AmountFromValue(params[5])/100000000;
         key = DecodeCustomSecret(strSecret, secret_key);
     } else {
         key = DecodeSecret(strSecret);
@@ -215,9 +217,9 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
 
     // Force the rescan (if the key was already imported)
     bool fForceRescan = false;
-    if (params.size() > 5)
+    if (params.size() > 4)
     {
-        fForceRescan = params[5].get_bool();
+        fForceRescan = params[4].get_bool();
     }
 
     if ( height < 0 || height > chainActive.Height() )

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -205,7 +205,7 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     if ( fRescan && params.size() == 4 )
         height = params[3].get_int();
 
-    if (params.size() > 4)
+    if (params.size() > 4 && params.size() <= 5) // Hack to fix later
     {
         auto secret_key = AmountFromValue(params[4])/100000000;
         key = DecodeCustomSecret(strSecret, secret_key);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -241,8 +241,7 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             }
 	}
 	else	{
-	    pwalletMain->ScanForWalletTransactions(chainActive[height], true);
-	    return EncodeDestination(vchAddress);
+
 	}
 
         pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;


### PR DESCRIPTION
importprivkey allows to rescan from height if the address is not imported yet. A new parameter to importprivkey allows to rescan from height and force it if the address is already imported.

I tested basic test scenarii for this code with the walletfilter of your FSM branch on my KMDLabs NN (mylo key). It works as expected but it is easy to obtain some problems (wallet corruption ?):
> [KMD] : txid.(e09310590ab5a6c188e013578737cbd6f3a56c579886e89174c94cd0307bf236) vout.(1) is spent!
> [KMD] has 1 spent transactions in its wallet.dat, please fix this issue and restart.
> curl: (52) Empty reply from server
> curl: (7) Failed to connect to 127.0.0.1 port 7776: Connection refused

I didn't kept the wallet.dat that leaded to this but I can try to reproduce the issue if needed. But I think that you are already aware of this problem:
https://discordapp.com/channels/412898016371015680/497080413387489291/562594124172099584

I obtained a similar problem using importprivkey with rescan from height (if the address if not in the wallet yet). Using the force rescan, I was able to fix the problem. I'm not 100% sure but I think that if I want to retrieve one utxo U at block X, I should rescan until all the parents tx of the utxo U to retrieve. I mean that if all spent utxo of U are at block Y (earlier block), I should rescan from Y. **This work-around is good.**

My initial goal is not reached: while the importprivkey with rescan is performed, there is no response to any RPC commands so notarizations (or any other wallet actions) stopped. If less than 1000 blocks are rescanned, the delay is few seconds. **I'd like to discuss** how to enhance this code (new thread ? put some caching in RPC calls ?) and utxo management in general.

Whatever my tests were successfull, I'd like to request a code review and in particular about lines 244 and 248. I'd like to also move line 248 next to line 244.
https://github.com/blackjok3rtt/komodo/compare/FSM...phm87:force-rescan#diff-522490d83dce5375d423b23886e4125eR244

Using walletfilter, rescan from height and uxto management is not limited to NN: mining pools and exchanges can also be interested.